### PR TITLE
Add "@types/react-router-dom" package, remove unused "useEffect" import, and change Button onClick prop arguments to "unknown"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
          },
          "devDependencies": {
             "@types/react": "^18.0.28",
+            "@types/react-router-dom": "^5.3.3",
             "@types/styled-components": "^5.1.26"
          }
       },
@@ -3862,6 +3863,12 @@
             "@types/node": "*"
          }
       },
+      "node_modules/@types/history": {
+         "version": "4.7.11",
+         "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+         "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+         "dev": true
+      },
       "node_modules/@types/hoist-non-react-statics": {
          "version": "3.3.1",
          "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -3981,6 +3988,27 @@
          "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
          "dependencies": {
             "@types/react": "*"
+         }
+      },
+      "node_modules/@types/react-router": {
+         "version": "5.1.20",
+         "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+         "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+         "dev": true,
+         "dependencies": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*"
+         }
+      },
+      "node_modules/@types/react-router-dom": {
+         "version": "5.3.3",
+         "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+         "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+         "dev": true,
+         "dependencies": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router": "*"
          }
       },
       "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
    },
    "devDependencies": {
       "@types/react": "^18.0.28",
+      "@types/react-router-dom": "^5.3.3",
       "@types/styled-components": "^5.1.26"
    }
 }

--- a/src/contexts/AuthContext/index.tsx
+++ b/src/contexts/AuthContext/index.tsx
@@ -1,5 +1,5 @@
+import { createContext, useState } from 'react'
 import type { AuthContextProps, ILogIn, IProps, ISignUp, User } from './types'
-import { createContext, useEffect, useState } from 'react'
 
 const URL = process.env.REACT_APP_API_URL
 
@@ -8,13 +8,12 @@ export const AuthContext = createContext<AuthContextProps>({
    isAuthenticated: false,
    login: async () => {},
    logout: async () => {},
-   signup: async () => {}
+   signup: async () => {},
 })
 
 function AuthContextProvider({ children }: IProps) {
    const [user, setUser] = useState<User | null>(null)
    const isAuthenticated = !!user
-
 
    const login: ILogIn = async (email, password) => {
       try {
@@ -75,7 +74,6 @@ function AuthContextProvider({ children }: IProps) {
       }
    }
 
-
    const getUserData = async (access_token: string) => {
       try {
          const response = await fetch(`${URL}/user/data`, {
@@ -91,11 +89,7 @@ function AuthContextProvider({ children }: IProps) {
       }
    }
 
-   return (
-      <AuthContext.Provider value={{ user, isAuthenticated, login, logout, signup }}>
-         {children}
-      </AuthContext.Provider>
-   )
+   return <AuthContext.Provider value={{ user, isAuthenticated, login, logout, signup }}>{children}</AuthContext.Provider>
 }
 
 export default AuthContextProvider

--- a/src/shared/components/Button/Button.types.ts
+++ b/src/shared/components/Button/Button.types.ts
@@ -1,5 +1,5 @@
 export interface IButtonProps {
    type?: 'primary-button' | 'secondary-button' | 'tertiary-button'
-   onClick: (args: any) => void
+   onClick: (args: unknown) => void
    content: string
 }


### PR DESCRIPTION
This pull request makes several changes to improve the codebase's type safety and reduce unnecessary imports.

Firstly, the "@types/react-router-dom" package has been added to the development dependencies. This package provides type definitions for the react-router-dom package, which we are using in our project. By adding these type definitions, we can improve the type safety of our codebase and catch potential errors at compile-time.

Secondly, an unused "useEffect" import from React has been removed. This import was not being used anywhere in the codebase, so it was safe to remove it.

Finally, the arguments of the onClick prop in the Button component have been changed to use "unknown" instead of "any". This change makes the code more type-safe by ensuring that the onClick prop is only called with arguments that are compatible with the "unknown" type. This can help catch potential errors at compile-time and make the code more robust.

![image](https://user-images.githubusercontent.com/85802138/229832073-429922b7-1cfd-4cfe-807b-c55b443d9c20.png)

Overall, this pull request makes several small but important changes to improve the quality of the codebase and make it more type-safe.

